### PR TITLE
NS_DESIGNATED_INITIALIZER

### DIFF
--- a/YWebView/Classes/YWebView.m
+++ b/YWebView/Classes/YWebView.m
@@ -76,7 +76,7 @@
 
 - (instancetype)initWithCoder:(NSCoder *)coder
 {
-    return [self initWithCoder:coder];
+    return [super initWithCoder:coder];
 }
 
 - (instancetype)initWithFrame:(CGRect)frame

--- a/YWebView/Classes/YWebView.m
+++ b/YWebView/Classes/YWebView.m
@@ -74,6 +74,11 @@
     return [self initWithFrame:CGRectZero];
 }
 
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+    return [self initWithCoder:coder];
+}
+
 - (instancetype)initWithFrame:(CGRect)frame
 {
     return [self initWithFrame:frame configuration:nil];


### PR DESCRIPTION
Xcode warns that initwithCoder: should be implemented because it is marked as NS_DESIGNATED_INITIALIZER for WKWebView.
